### PR TITLE
Unescape HTML in done_message

### DIFF
--- a/app/views/shared/_congrats.html.haml
+++ b/app/views/shared/_congrats.html.haml
@@ -7,7 +7,7 @@
   - else
 
     %h1 You're done with the #{lesson.name} Lesson. Way to go!
-    = lesson.done_message
+    != lesson.done_message
     %br
     %br
     %br


### PR DESCRIPTION
Unescape HTML in message after the lesson to fix the link:
![capture](https://user-images.githubusercontent.com/13780169/31264402-790cad4a-aa71-11e7-8c37-f040622c7f3a.PNG)